### PR TITLE
Fix link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 # sveltekit-instagram-infinite-scroll
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/rodneylab/sveltekit-infinite-scroll)
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/rodneylab/sveltekit-instagram-infinite-scroll)
 
 SvelteKit demo code for implementing an infinite scrolling feed in SvelteKit. The code accompanies the <a aria-label="Open Rodney Lab blog post on Svelte Kit Graph Q L queries with fetch only" href="https://rodneylab.com/sveltekit-infinite-scroll/">post on SvelteKit infinite scroll</a>. If you have any questions, please drop a comment at the bottom of that page.
 


### PR DESCRIPTION
Updated the link because the repo must have been renamed at some point

# Description

Updated the link to Stackblitz so that it doesn't say it is wasn't found

## Type of change

- [✓] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I vised the link

# Checklist:

- [ ✓] I have performed a self-review of my own code
